### PR TITLE
adds write operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "npm run clean && tsc",
     "clean": "del-cli ./dist",
+    "lint": "npm run lint:eslint && npm run lint:prettier && npm run lint:types",
     "lint:eslint": "eslint ./src --ext .ts",
     "lint:prettier": "prettier \"src/**/*.ts\" --cache --check",
     "lint:types": "tsc --noEmit --skipLibCheck && tsc-strict",

--- a/src/helpers/NotionHelper.test.ts
+++ b/src/helpers/NotionHelper.test.ts
@@ -13,6 +13,15 @@ import {
   readSingleRelationOrFail,
   readTitle,
   readTitleOrFail,
+  writeBoolean,
+  writeDateTimeStart,
+  writeEMail,
+  writeNumber,
+  writePhoneNumber,
+  writeRelationIdList,
+  writeRichText,
+  writeSingleRelation,
+  writeTitle,
 } from './NotionHelper';
 import type { NotionRawEntity, SimplifiedNotionEntity } from '../types';
 import { readRichText } from './NotionHelper';
@@ -715,6 +724,313 @@ describe('NotionHelper', () => {
           'email',
         );
       }).toThrow('Property "email was undefined. abort.');
+    });
+  });
+
+  describe('writeTitle', () => {
+    it('should return a valid TitlePropertyUpdate object', () => {
+      const value = 'Test Title';
+      const result = writeTitle(value);
+      expect(result).toEqual({
+        title: [
+          {
+            text: {
+              content: value,
+            },
+          },
+        ],
+        type: 'title',
+      });
+    });
+
+    it('should handle an empty string as input', () => {
+      const value = '';
+      const result = writeTitle(value);
+      expect(result).toEqual({
+        title: [
+          {
+            text: {
+              content: value,
+            },
+          },
+        ],
+        type: 'title',
+      });
+    });
+  });
+
+  describe('writeRichText', () => {
+    it('should return a valid RichTextPropertyUpdate object', () => {
+      const value = 'Test Rich Text';
+      const result = writeRichText(value);
+      expect(result).toEqual({
+        rich_text: [
+          {
+            text: {
+              content: value,
+            },
+          },
+        ],
+        type: 'rich_text',
+      });
+    });
+
+    it('should handle an empty string as input', () => {
+      const value = '';
+      const result = writeRichText(value);
+      expect(result).toEqual({
+        rich_text: [
+          {
+            text: {
+              content: value,
+            },
+          },
+        ],
+        type: 'rich_text',
+      });
+    });
+  });
+
+  describe('writeNumber', () => {
+    it('should return a valid NumberPropertyUpdate object with a number value', () => {
+      const value = 42;
+      const result = writeNumber(value);
+      expect(result).toEqual({
+        number: value,
+        type: 'number',
+      });
+    });
+
+    it('should return a valid NumberPropertyUpdate object with a null value', () => {
+      const value = null;
+      const result = writeNumber(value);
+      expect(result).toEqual({
+        number: value,
+        type: 'number',
+      });
+    });
+
+    it('should handle zero as input', () => {
+      const value = 0;
+      const result = writeNumber(value);
+      expect(result).toEqual({
+        number: value,
+        type: 'number',
+      });
+    });
+
+    it('should handle negative numbers as input', () => {
+      const value = -42;
+      const result = writeNumber(value);
+      expect(result).toEqual({
+        number: value,
+        type: 'number',
+      });
+    });
+
+    it('should handle decimal numbers as input', () => {
+      const value = 3.14;
+      const result = writeNumber(value);
+      expect(result).toEqual({
+        number: value,
+        type: 'number',
+      });
+    });
+  });
+
+  describe('readBoolean', () => {
+    interface TestEntity extends SimplifiedNotionEntity {
+      boolean: boolean;
+    }
+
+    const mockEntry: NotionRawEntity = {
+      properties: {
+        // @ts-ignore
+        boolean: { checkbox: true },
+      },
+    };
+
+    it('should read the boolean property', () => {
+      const result = readBoolean<TestEntity>(mockEntry, 'boolean');
+      expect(result).toBe(true);
+    });
+
+    it('should return undefined if boolean property does not exist', () => {
+      const result = readBoolean<TestEntity>({ properties: {} } as NotionRawEntity, 'boolean');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined if boolean value is not available', () => {
+      const result = readBoolean<TestEntity>(
+        {
+          properties: {
+            // @ts-ignore
+            boolean: {},
+          },
+        } satisfies NotionRawEntity,
+        'boolean',
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+  describe('writeBoolean', () => {
+    it('should return a valid CheckboxPropertyUpdate object with a true value', () => {
+      const value = true;
+      const result = writeBoolean(value);
+      expect(result).toEqual({
+        checkbox: value,
+        type: 'checkbox',
+      });
+    });
+
+    it('should return a valid CheckboxPropertyUpdate object with a false value', () => {
+      const value = false;
+      const result = writeBoolean(value);
+      expect(result).toEqual({
+        checkbox: value,
+        type: 'checkbox',
+      });
+    });
+  });
+  describe('writeDateTimeStart', () => {
+    it('should return a valid DateTimeStartPropertyUpdate object with a valid date', () => {
+      const value = new Date('2023-01-01T00:00:00Z');
+      const result = writeDateTimeStart(value);
+      expect(result).toEqual({
+        start: value.toISOString(),
+        type: 'date',
+      });
+    });
+
+    it('should handle a date with a different timezone', () => {
+      const value = new Date('2023-01-01T12:00:00+02:00');
+      const result = writeDateTimeStart(value);
+      expect(result).toEqual({
+        start: value.toISOString(),
+        type: 'date',
+      });
+    });
+
+    it('should handle the current date', () => {
+      const value = new Date();
+      const result = writeDateTimeStart(value);
+      expect(result).toEqual({
+        start: value.toISOString(),
+        type: 'date',
+      });
+    });
+  });
+  describe('writePhoneNumber', () => {
+    it('should return a valid PhoneNumberPropertyUpdate object with a string value', () => {
+      const value = '1234567890';
+      const result = writePhoneNumber(value);
+      expect(result).toEqual({
+        phone_number: value,
+        type: 'phone_number',
+      });
+    });
+
+    it('should return a valid PhoneNumberPropertyUpdate object with a null value', () => {
+      const value = null;
+      const result = writePhoneNumber(value);
+      expect(result).toEqual({
+        phone_number: value,
+        type: 'phone_number',
+      });
+    });
+
+    it('should handle an empty string as input', () => {
+      const value = '';
+      const result = writePhoneNumber(value);
+      expect(result).toEqual({
+        phone_number: value,
+        type: 'phone_number',
+      });
+    });
+  });
+  describe('writeEMail', () => {
+    it('should return a valid EMailPropertyUpdate object with a string value', () => {
+      const value = 'test@example.com';
+      const result = writeEMail(value);
+      expect(result).toEqual({
+        email: value,
+        type: 'email',
+      });
+    });
+
+    it('should return a valid EMailPropertyUpdate object with a null value', () => {
+      const value = null;
+      const result = writeEMail(value);
+      expect(result).toEqual({
+        email: value,
+        type: 'email',
+      });
+    });
+
+    it('should handle an empty string as input', () => {
+      const value = '';
+      const result = writeEMail(value);
+      expect(result).toEqual({
+        email: value,
+        type: 'email',
+      });
+    });
+  });
+
+  describe('writeSingleRelation', () => {
+    it('should return a valid SingleRelationPropertyUpdate object with a valid string value', () => {
+      const value = 'relation-id';
+      const result = writeSingleRelation(value);
+      expect(result).toEqual({
+        relation: [
+          {
+            id: value,
+          },
+        ],
+        type: 'relation',
+      });
+    });
+
+    it('should handle an empty string as input', () => {
+      const value = '';
+      const result = writeSingleRelation(value);
+      expect(result).toEqual({
+        relation: [
+          {
+            id: value,
+          },
+        ],
+        type: 'relation',
+      });
+    });
+  });
+
+  describe('writeRelationIdList', () => {
+    it('should return a valid RelationIdListPropertyUpdate object with a list of IDs', () => {
+      const idList = ['relation-id-1', 'relation-id-2'];
+      const result = writeRelationIdList(idList);
+      expect(result).toEqual({
+        relation: [{ id: 'relation-id-1' }, { id: 'relation-id-2' }],
+        type: 'relation',
+      });
+    });
+
+    it('should return an empty relation array when given an empty list', () => {
+      const idList: string[] = [];
+      const result = writeRelationIdList(idList);
+      expect(result).toEqual({
+        relation: [],
+        type: 'relation',
+      });
+    });
+
+    it('should handle a single ID in the list', () => {
+      const idList = ['relation-id-1'];
+      const result = writeRelationIdList(idList);
+      expect(result).toEqual({
+        relation: [{ id: 'relation-id-1' }],
+        type: 'relation',
+      });
     });
   });
 });

--- a/src/helpers/NotionHelper.ts
+++ b/src/helpers/NotionHelper.ts
@@ -1,4 +1,17 @@
-import type { NotionRawEntity, Relation, SimplifiedNotionEntity } from '../types';
+import type {
+  CheckboxPropertyUpdate,
+  DateTimeStartPropertyUpdate,
+  EMailPropertyUpdate,
+  NotionRawEntity,
+  NumberPropertyUpdate,
+  PhoneNumberPropertyUpdate,
+  Relation,
+  RelationIdListPropertyUpdate,
+  RichTextPropertyUpdate,
+  SimplifiedNotionEntity,
+  SingleRelationPropertyUpdate,
+  TitlePropertyUpdate,
+} from '../types';
 
 export function readProperty<NotionType extends SimplifiedNotionEntity>(
   entry: NotionRawEntity,
@@ -36,6 +49,19 @@ export function readTitleOrFail<NotionType extends SimplifiedNotionEntity>(
   return orFail<NotionType, string>(propertyName, readTitle<NotionType>(entry, propertyName));
 }
 
+export function writeTitle(value: string): TitlePropertyUpdate {
+  return {
+    title: [
+      {
+        text: {
+          content: value,
+        },
+      },
+    ],
+    type: 'title',
+  };
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Rich Text
 ///////////////////////////////////////////////////////////////////////////////
@@ -52,6 +78,19 @@ export function readRichTextOrFail<NotionType extends SimplifiedNotionEntity>(
   propertyName: keyof NotionType,
 ): string {
   return orFail<NotionType, string>(propertyName, readRichText(entry, propertyName));
+}
+
+export function writeRichText(value: string): RichTextPropertyUpdate {
+  return {
+    rich_text: [
+      {
+        text: {
+          content: value,
+        },
+      },
+    ],
+    type: 'rich_text',
+  };
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -72,6 +111,13 @@ export function readNumberOrFail<NotionType extends SimplifiedNotionEntity>(
   return orFail<NotionType, number>(propertyName, readNumber(entry, propertyName));
 }
 
+export function writeNumber(value: number | null): NumberPropertyUpdate {
+  return {
+    number: value,
+    type: 'number',
+  };
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Boolean
 ///////////////////////////////////////////////////////////////////////////////
@@ -88,6 +134,13 @@ export function readBooleanOrFail<NotionType extends SimplifiedNotionEntity>(
   propertyName: keyof NotionType,
 ): boolean {
   return orFail<NotionType, boolean>(propertyName, readBoolean(entry, propertyName));
+}
+
+export function writeBoolean(value: boolean): CheckboxPropertyUpdate {
+  return {
+    checkbox: value,
+    type: 'checkbox',
+  };
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -108,6 +161,13 @@ export function readDateTimeStartOrFail<NotionType extends SimplifiedNotionEntit
   return orFail<NotionType, Date>(propertyName, readDateTimeStart(entry, propertyName));
 }
 
+export function writeDateTimeStart(value: Date): DateTimeStartPropertyUpdate {
+  return {
+    start: value.toISOString(),
+    type: 'date',
+  };
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Phone Number
 ///////////////////////////////////////////////////////////////////////////////
@@ -126,8 +186,15 @@ export function readPhoneNumberOrFail<NotionType extends SimplifiedNotionEntity>
   return orFail<NotionType, number>(propertyName, readPhoneNumber(entry, propertyName));
 }
 
+export function writePhoneNumber(value: string | null): PhoneNumberPropertyUpdate {
+  return {
+    phone_number: value,
+    type: 'phone_number',
+  };
+}
+
 ///////////////////////////////////////////////////////////////////////////////
-// Phone Number
+// Email
 ///////////////////////////////////////////////////////////////////////////////
 
 export function readEMail<NotionType extends SimplifiedNotionEntity>(
@@ -142,6 +209,13 @@ export function readEMailOrFail<NotionType extends SimplifiedNotionEntity>(
   propertyName: keyof NotionType,
 ): string {
   return orFail<NotionType, string>(propertyName, readEMail(entry, propertyName));
+}
+
+export function writeEMail(value: string | null): EMailPropertyUpdate {
+  return {
+    email: value,
+    type: 'email',
+  };
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -160,6 +234,17 @@ export function readSingleRelationOrFail<NotionType extends SimplifiedNotionEnti
   propertyName: keyof NotionType,
 ): Relation {
   return orFail(propertyName, readSingleRelation(entry, propertyName));
+}
+
+export function writeSingleRelation(value: string): SingleRelationPropertyUpdate {
+  return {
+    relation: [
+      {
+        id: value,
+      },
+    ],
+    type: 'relation',
+  };
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -184,4 +269,13 @@ export function readRelationIdListOrFail<NotionType extends SimplifiedNotionEnti
   propertyName: keyof NotionType,
 ): string[] {
   return orFail(propertyName, readRelationIdList(entry, propertyName));
+}
+
+export function writeRelationIdList(idList: string[]): RelationIdListPropertyUpdate {
+  return {
+    relation: idList.map((id) => {
+      return { id };
+    }),
+    type: 'relation',
+  };
 }

--- a/src/types/NotionTypes.ts
+++ b/src/types/NotionTypes.ts
@@ -1,5 +1,5 @@
-import { Client } from '@notionhq/client';
-import {
+import type { Client } from '@notionhq/client';
+import type {
   DatabaseObjectResponse,
   PageObjectResponse,
   PartialDatabaseObjectResponse,
@@ -35,3 +35,77 @@ export type NotionRawEntity =
   | DatabaseObjectResponse;
 
 export type NotionRawEntityOrNull = NotionRawEntity | null;
+
+export type TitlePropertyUpdate = {
+  title: [
+    {
+      text: {
+        content: string;
+      };
+    },
+  ];
+  type: 'title';
+};
+
+export type RichTextPropertyUpdate = {
+  rich_text: [
+    {
+      text: {
+        content: string;
+      };
+    },
+  ];
+  type: 'rich_text';
+};
+
+export type NumberPropertyUpdate = {
+  number: number | null;
+  type: 'number';
+};
+
+export type CheckboxPropertyUpdate = {
+  checkbox: boolean;
+  type: 'checkbox';
+};
+
+export type DateTimeStartPropertyUpdate = {
+  start: string | null;
+  type: 'date';
+};
+
+export type PhoneNumberPropertyUpdate = {
+  phone_number: string | null;
+  type: 'phone_number';
+};
+
+export type EMailPropertyUpdate = {
+  email: string | null;
+  type: 'email';
+};
+
+export type SingleRelationPropertyUpdate = {
+  relation: [
+    {
+      id: string;
+    },
+  ];
+  type: 'relation';
+};
+
+export type RelationIdListPropertyUpdate = {
+  relation: {
+    id: string;
+  }[];
+  type: 'relation';
+};
+
+export type PropertyUpdate =
+  | TitlePropertyUpdate
+  | RichTextPropertyUpdate
+  | DateTimeStartPropertyUpdate
+  | CheckboxPropertyUpdate
+  | NumberPropertyUpdate
+  | PhoneNumberPropertyUpdate
+  | EMailPropertyUpdate
+  | SingleRelationPropertyUpdate
+  | RelationIdListPropertyUpdate;


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and testing of the `NotionHelper` module. The most important changes include the addition of new write functions for various Notion properties, the corresponding updates to the `NotionTypes` file, and the addition of comprehensive tests for the new functions.

### Enhancements to `NotionHelper` module:

* Added new write functions for different Notion properties, including `writeTitle`, `writeRichText`, `writeNumber`, `writeBoolean`, `writeDateTimeStart`, `writePhoneNumber`, `writeEMail`, `writeSingleRelation`, and `writeRelationIdList` in `src/helpers/NotionHelper.ts` [[1]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R52-R64) [[2]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R83-R95) [[3]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R114-R120) [[4]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R139-R145) [[5]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R164-R170) [[6]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R189-R197) [[7]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R214-R220) [[8]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R239-R249) [[9]](diffhunk://#diff-5575b1df83c1d46c1821a0f571127ee5eb0f9e968b8249e4d59a80df3d781e47R273-R281).

### Updates to `NotionTypes`:

* Introduced new types for property updates, such as `TitlePropertyUpdate`, `RichTextPropertyUpdate`, `NumberPropertyUpdate`, `CheckboxPropertyUpdate`, `DateTimeStartPropertyUpdate`, `PhoneNumberPropertyUpdate`, `EMailPropertyUpdate`, `SingleRelationPropertyUpdate`, and `RelationIdListPropertyUpdate` in `src/types/NotionTypes.ts`.

### Testing improvements:

* Added comprehensive tests for the new write functions in `src/helpers/NotionHelper.test.ts`, including tests for `writeTitle`, `writeRichText`, `writeNumber`, `writeBoolean`, `writeDateTimeStart`, `writePhoneNumber`, `writeEMail`, `writeSingleRelation`, and `writeRelationIdList`.

### Other changes:

* Updated `package.json` to include a new lint script that runs ESLint, Prettier, and TypeScript checks.
* Updated imports in `src/helpers/NotionHelper.ts` to include the new property update types.

These changes collectively improve the functionality, maintainability, and test coverage of the `NotionHelper` module.